### PR TITLE
Media uploading endpoints are served by a different domain

### DIFF
--- a/resources/endpoints.edn
+++ b/resources/endpoints.edn
@@ -180,9 +180,9 @@
 
  ;; Upload media
  ;; https://developer.twitter.com/en/docs/media/upload-media/api-reference
- {:path "/media/upload"          :request-method :post}
+ {:server-name "upload.twitter.com" :path "/media/upload"          :request-method :post}
  ; {:path "/media/upload"          :request-method :get}
- {:path "/media/metadata/create" :request-method :post}
+ {:server-name "upload.twitter.com" :path "/media/metadata/create" :request-method :post}
 
  ;; Trends
 


### PR DESCRIPTION
It's upload.twitter.com
1. media/upload – https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload
2. media/metadata/create – https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create